### PR TITLE
App name localization not working on iOS

### DIFF
--- a/hooks/before-prepare.ios.ts
+++ b/hooks/before-prepare.ios.ts
@@ -44,8 +44,8 @@ export class BeforePrepareIOS extends BeforePrepareCommon {
     const languageResourcesDir = path.join(this.appResourcesDirectoryPath, `${language}.lproj`);
     this
       .createDirectoryIfNeeded(languageResourcesDir)
-      .writeStrings(languageResourcesDir, "Localizable.strings", localizableStrings)
-      .writeStrings(languageResourcesDir, "InfoPlist.strings", infoPlistStrings)
+      .writeStrings(languageResourcesDir, "Localizable.strings", localizableStrings, true)
+      .writeStrings(languageResourcesDir, "InfoPlist.strings", infoPlistStrings, false)
     ;
     if (isDefaultLanguage) {
       infoPlistStrings.push({ key: "CFBundleDevelopmentRegion", value: language });
@@ -54,10 +54,10 @@ export class BeforePrepareIOS extends BeforePrepareCommon {
     return this;
   }
 
-  private writeStrings(languageResourcesDir: string, resourceFileName: string, strings: I18nEntry[]): this {
+  private writeStrings(languageResourcesDir: string, resourceFileName: string, strings: I18nEntry[], encodeKeys: boolean): this {
     let content = "";
     for (const { key, value } of strings) {
-      content += `"${encodeKey(key)}" = "${encodeValue(value)}";\n`;
+      content += `"${encodeKeys ? encodeKey(key) : key}" = "${encodeValue(value)}";\n`;
     }
     const resourceFilePath = path.join(languageResourcesDir, resourceFileName);
     this.writeFileSyncIfNeeded(resourceFilePath, content);


### PR DESCRIPTION
Hi,

Your library works great, except for one thing (that I've fixed with this PR): on iOS, the appname is always according to the default appname. Changing the language on the device doesn't have any effect.

The cause sees to be the encoding of the keys in `InfoPlist.strings`. The hook fi. changes `CFBundleDisplayName` to something like `"_2ba372365d90c7cac414804b2aff4549d3e46ca8" which iOS can't relate back to the `CFBundleDisplayName` key. At least not on my iOS 9 simulator.

Not encoding the keys in `InfoPlist.strings` fixes it.

Thanks,
Eddy