### PR TITLE
update the README.md to include that app.name is mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ const i18n = {
 module.exports = i18n;
 ```
 
+If you get a `No resource found that matches the given name (at 'label' with value '@string/title_activity_kimera')` when building the app, you have to set the `"app.name"` in at least the `.default` translation file.
 ## Frequently asked questions
 ### How to set the default language?
 Add the `.default` extension to the default language file to set it as the fallback language:


### PR DESCRIPTION
Hi
I got the same error as discussed [here](https://github.com/NativeScript/nativescript-angular/issues/742). At least for me, it wasn't clear enough that I'd need the `app.name` in the translation file/s. 
Given that I haven't changed my android manifest file, which references the `@string/title_activity_kimera`, I guess a few people might experience the same issue.