### PR TITLE
Fixed invalid files in i18n folder braking builds

### DIFF
--- a/hooks/converter.common.ts
+++ b/hooks/converter.common.ts
@@ -75,7 +75,10 @@ export abstract class ConverterCommon extends EventEmitter {
     fs.readdirSync(this.i18nDirectoryPath).map(fileName => {
       return path.join(this.i18nDirectoryPath, fileName);
     }).filter(filePath => {
-      return fs.statSync(filePath).isFile();
+      const validExtensions = [".js", ".json"];
+      const isValidExtension = validExtensions.indexOf(path.extname(filePath)) > -1;
+      const isFile = fs.statSync(filePath).isFile();
+      return isFile && isValidExtension;
     }).forEach(filePath => {
       let language = path.basename(filePath, path.extname(filePath));
       if (path.extname(language) === ".default") {


### PR DESCRIPTION
The before-prepare hook will now only look for `.js` and `.json` files in the `i18n` folder.

Fixes #37 