### PR TITLE
Support NSConfig's appPath 

### DIFF
--- a/hooks/converter.common.ts
+++ b/hooks/converter.common.ts
@@ -26,7 +26,8 @@ export abstract class ConverterCommon extends EventEmitter {
       .platformProjectService
       .getAppResourcesDestinationDirectoryPath(projectData)
     ;
-    this.i18nDirectoryPath = path.join(projectData.projectDir, "app", "i18n");
+
+    this.i18nDirectoryPath = path.join(projectData.appDirectoryPath, "i18n");
   }
 
   protected abstract cleanObsoleteResourcesFiles(

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nativescript-localize",
   "description": "Native internationalization plugin for NativeScript using native capabilities of each platform",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "keywords": [
     "nativescript",
     "internationalization",
@@ -24,6 +24,10 @@
     {
       "name": "Eddy Verbruggen",
       "email": "eddyverbruggen@gmail.com"
+    },
+    {
+      "name": "Brendan Ingham",
+      "email": "brendan.ingham13@gmail.com"
     }
   ],
   "main": "index.js",


### PR DESCRIPTION
This PR Adds the ability to use the App with non-standard appPath set in nsconfig.json 

For Example :
```(javascript)
{
    "appPath": "src/app",
    "appResourcesPath": "src/resources"
}
```

I Raised the issue #41 and this PR closes #41 