### PR TITLE
Support for language codes with 3 letters

### DIFF
--- a/src/localize.android.ts
+++ b/src/localize.android.ts
@@ -44,6 +44,11 @@ export function androidLaunchEventLocalizationHandler() {
 }
 
 export function overrideLocale(locale: string): boolean {
-  setString("__app__language__", locale.substring(0, 2));
+  let language_code = locale.substring(0, 2)
+  if (locale.indexOf('-') < 0 && locale.length == 3) {
+    language_code = locale
+  }
+
+  setString("__app__language__", language_code);
   return true;
 }

--- a/src/localize.ios.ts
+++ b/src/localize.ios.ts
@@ -25,7 +25,12 @@ export function androidLaunchEventLocalizationHandler() {
 }
 
 export function overrideLocale(locale: string): boolean {
-  const path = NSBundle.mainBundle.pathForResourceOfType(locale.substring(0, 2), "lproj");
+  let language_code = locale.substring(0, 2)
+  if (locale.indexOf('-') < 0 && locale.length == 3) {
+    language_code = locale
+  }
+
+  const path = NSBundle.mainBundle.pathForResourceOfType(language_code, "lproj");
 
   if (!path) {
     return false;
@@ -34,7 +39,7 @@ export function overrideLocale(locale: string): boolean {
   bundle = NSBundle.bundleWithPath(path);
   NSUserDefaults.standardUserDefaults.setObjectForKey([locale], "AppleLanguages");
   NSUserDefaults.standardUserDefaults.synchronize();
-  setString("__app__language__", locale.substring(0, 2));
+  setString("__app__language__", language_code);
 
   return true;
 }


### PR DESCRIPTION
### Summary
A very basic implementation that checks if a local is a 3 letter language code.